### PR TITLE
Stateless helpboard comp, refetch in mutation call, adjust timestamp model

### DIFF
--- a/client/src/components/ConnectionCard.js
+++ b/client/src/components/ConnectionCard.js
@@ -4,11 +4,10 @@ import PropTypes from 'prop-types';
 
 const ConnectionCard = ({ connection, index }) => {
   const { title, description, owner, timestamp } = connection;
-  const date = new Date(Number(timestamp)).toString();
 
   return (
     <div key={index} className="connection-card">
-      <p>Created: {date}</p>
+      <p>Created: {timestamp}</p>
       <p>By: {owner.username}</p>
       <h3>{title}</h3>
       <p>

--- a/client/src/components/CreateConnection.js
+++ b/client/src/components/CreateConnection.js
@@ -3,10 +3,9 @@ import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { graphql } from 'react-apollo';
 import CREATE_CONNECTION from '../mutations/CREATE_CONNECTION';
+import GET_CONNECTIONS from '../queries/GET_CONNECTIONS';
 
 const CreateConnection = ({ props, mutate, id }) => {
-  console.log('from create: ', id);
-
   const validateData = (e) => {
     e.preventDefault();
 
@@ -17,8 +16,8 @@ const CreateConnection = ({ props, mutate, id }) => {
         description: e.target.elements.description.value,
         lifespan: e.target.elements.lifespan.value,
       },
-    })
-      .then(props.history.push('/helpboard'));
+      refetchQueries: [{ query: GET_CONNECTIONS }],
+    }).then(props.history.push('/helpboard'));
   };
 
   return (

--- a/client/src/components/HelpBoard.js
+++ b/client/src/components/HelpBoard.js
@@ -1,9 +1,8 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { graphql } from 'react-apollo';
 import GET_CONNECTIONS from '../queries/GET_CONNECTIONS';
-
 import ConnectionCard from './ConnectionCard';
 
 /**
@@ -11,41 +10,30 @@ import ConnectionCard from './ConnectionCard';
  * Returns continuous feed of all connection cards created
  */
 
-class HelpBoard extends Component {
-  componentDidMount() {
-    console.log('this got hit');
-    this.props.data.refetch();
-  }
-
-  render() {
-    const { data } = this.props;
-
-    return (
-      <div className="helpboard-container">
-        <h1>Connect with other users!</h1>
-        <Link to="/new" className="button create-button">
-          <span><i className="fas fa-plus"></i></span>
-          new connection
-        </Link>
-        {
-          /**
-           * Map through all created connections
-           * Create a card for each connection
-           * TODO: order the cards by date/time created || ending soonest?
-           */
-          data.connections &&
-          <div className="connections-query-container">
-            {data.connections.map((connection, index) => (
-              <div key={index} className="connection-card-wrapper">
-                <ConnectionCard connection={connection} index={index}/>
-              </div>
-            ))}
+const HelpBoard = ({ data }) => (
+  <div className="helpboard-container">
+    <h1>Connect with other users!</h1>
+    <Link to="/new" className="button create-button">
+      <span><i className="fas fa-plus"></i></span>
+      new connection
+    </Link>
+    {
+      /**
+       * Map through all created connections
+       * Create a card for each connection
+       * TODO: order the cards by date/time created || ending soonest?
+       */
+      data.connections &&
+      <div className="connections-query-container">
+        {data.connections.map((connection, index) => (
+          <div key={index} className="connection-card-wrapper">
+            <ConnectionCard connection={connection} index={index}/>
           </div>
-        }
+        ))}
       </div>
-    );
-  }
-}
+    }
+  </div>
+);
 
 HelpBoard.propTypes = {
   data: PropTypes.object,

--- a/db/connection/connection.js
+++ b/db/connection/connection.js
@@ -28,8 +28,8 @@ const ConnectionSchema = new mongoose.Schema({
     },
   },
   timestamp: {
-    type: String,
-    default: String(Date.now()),
+    type: Date,
+    default: Date.now,
   },
   lifespan: {
     type: Number,

--- a/graphql/connection/resolvers.js
+++ b/graphql/connection/resolvers.js
@@ -19,7 +19,7 @@ const createConnection = (
   if (!ownerID || !title || !description || !lifespan) {
     throw new Error('Missing Required Fields');
   }
-  return new Connection({
+  return Connection.create({
     ownerID,
     title,
     description,


### PR DESCRIPTION
closes #77 

## Purpose
* Refactor existing code
* Timestamps weren't properly displaying different times
* Previous re-fetch method calls to DB each time

## Approach/Fixes
* Altered mongoose model schema:
```
  timestamp: {
    type: Date,
    default: Date.now,
  },
```
* Added re-fetch directly after mutation 
  * Allows `HelpBoard` component to be stateless

## Testing
* Download this PR
* Create a new connection. Quickly creates another shortly after and note difference in timestamps.

## Notes
* Was able to configure apollo client for cached store, but unable to configure all the steps on the frontend for mutations and re-fetching queries from the cache instead of the DB.
* Options: keep trying to figure it out or incorporate redux instead