### PR TITLE
Refactor express board, refetch on profile component

### DIFF
--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -4,7 +4,7 @@ import axios from 'axios';
 import PropTypes from 'prop-types';
 import Navbar from './Navbar';
 import Landing from './Landing';
-import HelpBoard from './HelpBoard';
+import ExpressBoard from './ExpressBoard';
 import CreateConnection from './CreateConnection';
 import Profile from './Profile';
 import NotFound from './NotFound';
@@ -49,8 +49,8 @@ class App extends Component {
                 component={() => <Landing signedIn={this.state.signedIn} />}
               />
               <Route
-                exact path="/helpboard"
-                component={props => <HelpBoard props={props} />}
+                exact path="/expressboard"
+                component={props => <ExpressBoard props={props} />}
               />
               <Route
                 exact path="/new"

--- a/client/src/components/CreateConnection.js
+++ b/client/src/components/CreateConnection.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { graphql } from 'react-apollo';
 import CREATE_CONNECTION from '../mutations/CREATE_CONNECTION';
 import GET_CONNECTIONS from '../queries/GET_CONNECTIONS';
+import GET_USER from '../queries/GET_USER';
 
 const CreateConnection = ({ props, mutate, id }) => {
   const validateData = (e) => {
@@ -16,8 +17,11 @@ const CreateConnection = ({ props, mutate, id }) => {
         description: e.target.elements.description.value,
         lifespan: e.target.elements.lifespan.value,
       },
-      refetchQueries: [{ query: GET_CONNECTIONS }],
-    }).then(props.history.push('/helpboard'));
+      refetchQueries: [
+        { query: GET_CONNECTIONS },
+        { query: GET_USER, variables: { id } },
+      ],
+    }).then(props.history.push('/expressboard'));
   };
 
   return (

--- a/client/src/components/ExpressBoard.js
+++ b/client/src/components/ExpressBoard.js
@@ -6,12 +6,12 @@ import GET_CONNECTIONS from '../queries/GET_CONNECTIONS';
 import ConnectionCard from './ConnectionCard';
 
 /**
- * Help Board component (Connections Feed)
+ * Express Board component (Connections Feed)
  * Returns continuous feed of all connection cards created
  */
 
-const HelpBoard = ({ data }) => (
-  <div className="helpboard-container">
+const ExpressBoard = ({ data }) => (
+  <div className="expressboard-container">
     <h1>Connect with other users!</h1>
     <Link to="/new" className="button create-button">
       <span><i className="fas fa-plus"></i></span>
@@ -35,10 +35,10 @@ const HelpBoard = ({ data }) => (
   </div>
 );
 
-HelpBoard.propTypes = {
+ExpressBoard.propTypes = {
   data: PropTypes.object,
   connection: PropTypes.array,
   map: PropTypes.func,
 };
 
-export default graphql(GET_CONNECTIONS)(HelpBoard);
+export default graphql(GET_CONNECTIONS)(ExpressBoard);

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -19,7 +19,7 @@ const Navbar = ({ props }) => {
           <NavLink to="/" id="chingu" className="link navbar-link">
             <img src="https://avatars1.githubusercontent.com/u/28485958?s=200&v=4" alt="chingu logo"/>
           </NavLink>
-          <NavLink to="/helpboard" className="link navbar-link">Help Board</NavLink>
+          <NavLink to="/expressboard" className="link navbar-link">Express Board</NavLink>
           <NavLink to={`/user/${data._id}`} className="link navbar-link">Profile</NavLink>
           <a href="http://localhost:8008/auth/logout" className="link navbar-link">Sign Out</a>
         </div>}

--- a/client/src/styles/components/_expressboard.scss
+++ b/client/src/styles/components/_expressboard.scss
@@ -1,4 +1,4 @@
-.helpboard-container {
+.expressboard-container {
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/client/src/styles/main.scss
+++ b/client/src/styles/main.scss
@@ -6,7 +6,7 @@
 @import './components/navbar';
 @import './components/app';
 @import './components/landing';
-@import './components/helpboard';
+@import './components/expressboard';
 @import './components/profile';
 @import './components/createConnection';
 

--- a/config/session.js
+++ b/config/session.js
@@ -1,8 +1,8 @@
 const session = require('express-session');
-const RedisStore = require('connect-redis')(session);
+// const RedisStore = require('connect-redis')(session);
 
 module.exports = session({
-  store: new RedisStore({ url: process.env.REDIS_URL }),
+  // store: new RedisStore({ url: process.env.REDIS_URL }),
   secret: process.env.SESSION_SECRET,
   resave: true,
   saveUninitialized: true,


### PR DESCRIPTION
* Commented out redis
* Renamed `HelpBoard` component to `ExpressBoard`
* Sync refetch query to update on `Profile` component

## Notes
* Currently working on setting up apollo client link state
* If unable, will get redux setup for local state management to avoid refetching data