### PR TITLE
MapStateToProps on CreateConnection component for redux

### DIFF
--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -57,7 +57,7 @@ class App extends Component {
               />
               <Route
                 exact path="/new"
-                component={props => <CreateConnection id={this.state.data._id} props={props}/>}
+                component={props => <CreateConnection props={props}/>}
               />
               <Route
                 path="/user/:id"

--- a/client/src/components/CreateConnection.js
+++ b/client/src/components/CreateConnection.js
@@ -1,12 +1,15 @@
 import React from 'react';
 import { withRouter } from 'react-router-dom';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { graphql } from 'react-apollo';
 import CREATE_CONNECTION from '../mutations/CREATE_CONNECTION';
 import GET_CONNECTIONS from '../queries/GET_CONNECTIONS';
 import GET_USER from '../queries/GET_USER';
 
-const CreateConnection = ({ props, mutate, id }) => {
+const CreateConnection = ({ props, auth, mutate }) => {
+  const id = auth.creds._id;
+
   const validateData = (e) => {
     e.preventDefault();
 
@@ -64,9 +67,16 @@ const CreateConnection = ({ props, mutate, id }) => {
 CreateConnection.propTypes = {
   props: PropTypes.object,
   history: PropTypes.object,
-  push: PropTypes.func,
   mutate: PropTypes.func,
-  id: PropTypes.string,
+  auth: PropTypes.object,
 };
 
-export default withRouter(graphql(CREATE_CONNECTION)(CreateConnection));
+const mapStateToProps = state => ({
+  auth: state.auth,
+});
+
+export default (withRouter(
+  graphql(CREATE_CONNECTION)(
+    (connect(mapStateToProps)(CreateConnection)),
+  ),
+));


### PR DESCRIPTION
closes #84 

* Added redux on `CreateConnection` component
* Handles ID through redux instead of react state

### Testing
* Download PR to your local device
* Login with github and try creating a new connection
  * A new connection card should show up in the last as well as your profile page without a page refresh